### PR TITLE
Remove leftover migration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ python main.py
 
 配置文件 `config.json` 包含以下字段：
 
-- `GITEA_URL`: Gitee API URL
-- `ACCESS_TOKEN`: Gitee 访问令牌
+- `PLATFORM`: 平台配置列表，每个元素包含：
+  - `NAME`: 平台名称，如 `gitee`、`github`
+  - `API_URL`: 对应平台的 API 地址
+  - `ACCESS_TOKEN`: 访问该平台的令牌
 - `PULL_REQUEST_LISTS`: 监控的 PR 列表，每个元素包含：
   - `OWNER`: 仓库拥有者
   - `REPO`: 仓库名称
@@ -83,8 +85,18 @@ python main.py
 
 ```json
 {
-    "GITEA_URL": "https://gitee.com/api/v5",
-    "ACCESS_TOKEN": "your_access_token_here",
+    "PLATFORM": [
+        {
+            "NAME": "gitee",
+            "API_URL": "https://gitee.com/api/v5",
+            "ACCESS_TOKEN": "your_access_token_here"
+        },
+        {
+            "NAME": "github",
+            "API_URL": "https://api.github.com",
+            "ACCESS_TOKEN": ""
+        }
+    ],
     "PULL_REQUEST_LISTS": [
         {
             "OWNER": "mindspore",

--- a/templates/config.html
+++ b/templates/config.html
@@ -45,7 +45,7 @@
                                     <div class="mb-3">
                                         <label for="gitee_access_token" class="form-label">Gitee 访问令牌:</label>
                                         <input type="password" class="form-control" id="gitee_access_token" name="gitee_access_token"
-                                            value="{{ config.get('ACCESS_TOKEN', '') }}" placeholder="输入 Gitee Access Token">
+                                            value="{{ config.get_access_token('gitee') }}" placeholder="输入 Gitee Access Token">
                                         <div class="form-text">用于访问 Gitee API 的访问令牌</div>
                                     </div>
                                 </div>
@@ -65,7 +65,7 @@
                                     <div class="mb-3">
                                         <label for="github_access_token" class="form-label">GitHub 访问令牌:</label>
                                         <input type="password" class="form-control" id="github_access_token" name="github_access_token"
-                                            value="{{ config.get('GITHUB_ACCESS_TOKEN', '') }}" placeholder="输入 GitHub Access Token">
+                                            value="{{ config.get_access_token('github') }}" placeholder="输入 GitHub Access Token">
                                         <div class="form-text">用于访问 GitHub API 的访问令牌 (可选)</div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- drop `_migrate_old_rules_if_needed` method
- simplify `load_config` now that no legacy files are migrated

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b2a286e54832d9fc729f55f56b4ec