### PR TITLE
Implement async API client framework

### DIFF
--- a/gitee_monitor/api/async_api_client_factory.py
+++ b/gitee_monitor/api/async_api_client_factory.py
@@ -1,0 +1,47 @@
+"""
+异步API客户端工厂类，管理不同平台的异步API客户端创建
+"""
+from typing import Dict, Type, Optional
+import logging
+
+from .async_base_api import AsyncBaseAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncAPIClientFactory:
+    """异步API客户端工厂类"""
+
+    _clients: Dict[str, Type[AsyncBaseAPIClient]] = {}
+
+    @classmethod
+    def register_client(cls, platform: str, client_class: Type[AsyncBaseAPIClient]) -> None:
+        cls._clients[platform.lower()] = client_class
+        logger.info(f"注册异步API客户端: {platform} -> {client_class.__name__}")
+
+    @classmethod
+    def create_client(cls, platform: str, api_url: str, access_token: str) -> Optional[AsyncBaseAPIClient]:
+        platform_key = platform.lower()
+        if platform_key not in cls._clients:
+            logger.error(f"不支持的平台: {platform}. 支持的平台: {list(cls._clients.keys())}")
+            return None
+
+        client_class = cls._clients[platform_key]
+        try:
+            client = client_class(api_url, access_token)
+            if not client.validate_config():
+                logger.error(f"异步API客户端配置无效: {platform}")
+                return None
+            logger.info(f"成功创建异步API客户端: {platform}")
+            return client
+        except Exception as e:
+            logger.error(f"创建异步API客户端失败 ({platform}): {e}")
+            return None
+
+    @classmethod
+    def get_supported_platforms(cls) -> list:
+        return list(cls._clients.keys())
+
+    @classmethod
+    def is_platform_supported(cls, platform: str) -> bool:
+        return platform.lower() in cls._clients

--- a/gitee_monitor/api/async_base_api.py
+++ b/gitee_monitor/api/async_base_api.py
@@ -85,7 +85,15 @@ class AsyncBaseAPIClient(ABC):
         pass
     
     @abstractmethod
-    async def get_author_prs(self, owner: str, repo: str, author: str) -> Optional[List[Dict[str, Any]]]:
+    async def get_author_prs(
+        self,
+        owner: str,
+        repo: str,
+        author: str,
+        state: str = "open",
+        page: int = 1,
+        per_page: int = 20,
+    ) -> Optional[List[Dict[str, Any]]]:
         """
         异步获取指定作者在指定仓库的所有PR
         
@@ -93,6 +101,9 @@ class AsyncBaseAPIClient(ABC):
             owner: 仓库拥有者
             repo: 仓库名称
             author: 作者用户名
+            state: PR 状态，可选 open/closed/all
+            page: 页码
+            per_page: 每页数量
             
         Returns:
             PR列表，出错时返回None
@@ -156,3 +167,11 @@ class AsyncBaseAPIClient(ABC):
         except Exception as e:
             logger.error(f"Unexpected error: {method} {url} - {e}")
             return None
+
+    def get_platform_name(self) -> str:
+        """获取平台名称"""
+        return self.__class__.__name__.lower().replace('apiclient', '')
+
+    def validate_config(self) -> bool:
+        """验证配置是否有效"""
+        return bool(self.api_url and self.access_token)

--- a/gitee_monitor/api/async_github_api.py
+++ b/gitee_monitor/api/async_github_api.py
@@ -1,0 +1,71 @@
+"""
+异步GitHub API 客户端模块，处理与 GitHub API 的所有交互
+"""
+import logging
+from typing import List, Dict, Any, Optional
+
+from .async_base_api import AsyncBaseAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncGitHubAPIClient(AsyncBaseAPIClient):
+    """异步GitHub API 客户端"""
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "GiteeMonitor/1.0",
+        }
+        if self.access_token:
+            headers["Authorization"] = f"token {self.access_token}"
+        return headers
+
+    async def get_pr_labels(self, owner: str, repo: str, pr_id: int) -> Optional[List[Dict[str, Any]]]:
+        url = f"{self.api_url}/repos/{owner}/{repo}/issues/{pr_id}/labels"
+        try:
+            return await self._make_request("GET", url)
+        except Exception as e:
+            logger.error(f"异步获取 GitHub PR #{pr_id} 标签失败: {e}")
+            return None
+
+    async def get_pr_details(self, owner: str, repo: str, pr_id: int) -> Optional[Dict[str, Any]]:
+        url = f"{self.api_url}/repos/{owner}/{repo}/pulls/{pr_id}"
+        try:
+            return await self._make_request("GET", url)
+        except Exception as e:
+            logger.error(f"异步获取 GitHub PR #{pr_id} 详情失败: {e}")
+            return None
+
+    async def get_author_prs(
+        self,
+        owner: str,
+        repo: str,
+        author: str,
+        state: str = "open",
+        page: int = 1,
+        per_page: int = 20,
+    ) -> Optional[List[Dict[str, Any]]]:
+        url = f"{self.api_url}/repos/{owner}/{repo}/pulls"
+        params = {
+            "state": state,
+            "sort": "created",
+            "direction": "desc",
+            "page": page,
+            "per_page": per_page,
+        }
+        try:
+            prs = await self._make_request("GET", url, params=params)
+            if prs is None:
+                return None
+            if author:
+                prs = [pr for pr in prs if pr.get("user", {}).get("login") == author]
+            return prs
+        except Exception as e:
+            logger.error(f"异步获取作者 {author} 在 {owner}/{repo} 的GitHub PR列表失败: {e}")
+            return None
+
+from .async_api_client_factory import AsyncAPIClientFactory
+
+AsyncAPIClientFactory.register_client("github", AsyncGitHubAPIClient)
+


### PR DESCRIPTION
## Summary
- extend `AsyncBaseAPIClient` with missing interfaces
- update `AsyncGiteeAPIClient` to accept pagination arguments and register in factory
- add new async `GitHub` client implementation
- introduce `AsyncAPIClientFactory` to manage async clients

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b376cea00832db5fb761395549b2c